### PR TITLE
Add GitHub Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,98 @@
+name: バグレポート
+description: バグや問題を報告する
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        バグを報告していただきありがとうございます。以下のフォームに記入してください。
+
+  - type: textarea
+    id: description
+    attributes:
+      label: バグの説明
+      description: バグの内容を簡潔に説明してください
+      placeholder: 何が起こりましたか？
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: 再現手順
+      description: バグを再現するための手順を記載してください
+      placeholder: |
+        1. '...'に移動
+        2. '...'をクリック
+        3. '...'まで下にスクロール
+        4. エラーが表示される
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待される動作
+      description: 本来どのような動作をすべきでしたか？
+      placeholder: 何が起こるべきでしたか？
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 実際の動作
+      description: 実際に何が起こりましたか？
+      placeholder: 実際に何が起こりましたか？
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: スクリーンショット
+      description: 可能であれば、スクリーンショットを添付してください
+      placeholder: スクリーンショットをドラッグ&ドロップ
+
+  - type: dropdown
+    id: browser
+    attributes:
+      label: ブラウザ
+      description: 使用しているブラウザを選択してください
+      options:
+        - Chrome
+        - Firefox
+        - Safari
+        - Edge
+        - その他
+    validations:
+      required: true
+
+  - type: input
+    id: browser-version
+    attributes:
+      label: ブラウザバージョン
+      description: ブラウザのバージョンを入力してください
+      placeholder: 例：120.0.0.0
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: OS
+      description: 使用しているOSを選択してください
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - iOS
+        - Android
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 追加情報
+      description: その他の情報があれば記載してください
+      placeholder: 関連する設定、コンソールエラーなど

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: ディスカッション
+    url: https://github.com/YuSabo90002/scotlandyard/discussions
+    about: 質問や一般的な議論はこちら

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: 機能リクエスト
+description: 新機能や改善を提案する
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        新機能や改善のアイデアを共有していただきありがとうございます。
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: 解決したい問題
+      description: この機能がどのような問題を解決しますか？
+      placeholder: 〜ができなくて困っています...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: 提案する解決策
+      description: どのような機能があれば問題が解決しますか？
+      placeholder: 〜という機能があれば...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 代替案
+      description: 他に検討した解決策はありますか？
+      placeholder: 〜も考えましたが...
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 追加情報
+      description: その他の情報、参考資料、モックアップなど
+      placeholder: 参考になるリンクや画像など


### PR DESCRIPTION
## Summary
GitHubのIssueテンプレートを追加し、バグレポートと機能リクエストの報告を構造化します。

## Changes
- **Bug Report Template** (`bug_report.yml`)
  - バグの説明、再現手順、期待される動作、実際の動作
  - ブラウザ、OS情報の収集
  - スクリーンショット添付機能
  
- **Feature Request Template** (`feature_request.yml`)
  - 解決したい問題、提案する解決策
  - 代替案、追加情報の記載欄

- **Config File** (`config.yml`)
  - ディスカッションへのリンク
  - 空のIssue作成を許可

## Benefits
- ✅ 構造化されたバグレポートで問題の再現が容易に
- ✅ 日本語対応でUX向上
- ✅ 必須フィールドによる情報の標準化
- ✅ Issue作成時のガイダンス提供

🤖 Generated with [Claude Code](https://claude.com/claude-code)